### PR TITLE
Fix terminal resizing bug

### DIFF
--- a/ssmclient/shell.go
+++ b/ssmclient/shell.go
@@ -2,12 +2,13 @@ package ssmclient
 
 import (
 	"errors"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ssm"
-	"github.com/mmmorris1975/ssm-session-client/datachannel"
 	"io"
 	"log"
 	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/mmmorris1975/ssm-session-client/datachannel"
 )
 
 // ShellSession starts a shell session with the instance specified in the target parameter.  The
@@ -46,16 +47,10 @@ func ShellSession(cfg aws.Config, target string) error {
 func updateTermSize(c datachannel.DataChannel) error {
 	rows, cols, err := getWinSize()
 	if err != nil {
-		log.Printf("getWinSize() failed: %v", err)
-	}
-
-	// make sure we set some default terminal size with contrived values
-	if rows < 1 {
-		rows = 45
-	}
-
-	if cols < 1 {
+		// make sure we set some default terminal size with contrived values
 		cols = 132
+		rows = 45
+		log.Printf("Could not get size of the terminal: %s, using width %d height %d\n", err, cols, rows)
 	}
 
 	return c.SetTerminalSize(rows, cols)


### PR DESCRIPTION
Hello!  I use the `ssm-session-client` code as a library to my own CLI tool.

I've noticed that compared to the AWS official SSM client, `ssm-session-client` doesn't deal well with terminal resizing (this is using Terminal.app on macOS).  I went digging a bit, and it seems AWS's client doesn't rely on getting a `SIGWINCH`, but simply sends terminal size every 500ms: 
https://github.com/aws/session-manager-plugin/blob/65933d1adf368d1efde7380380a19a7a691340c1/src/sessionmanagerplugin/session/shellsession/shellsession.go#L98-L134

I've adopted their trick here (along with some other minor changes), and it solves my issue.  I verified it by connecting to a remote EC2 shell and running:

```sh
tput lines
tput cols
```

These report updated values as expected when resizing the Terminal.app window.  Also, running a TUI app such as `vim` isn't garbled whereas without this patch it is.